### PR TITLE
Fixed an issue where we were grabbing the wrong inventory count

### DIFF
--- a/lib/active_fulfillment/fulfillment/services/amazon_mws.rb
+++ b/lib/active_fulfillment/fulfillment/services/amazon_mws.rb
@@ -245,7 +245,7 @@ module ActiveMerchant
         document.each_element('//InventorySupplyList/member') do |node|
           params = node.elements.to_a.each_with_object({}) { |elem, hash| hash[elem.name] = elem.text }
 
-          response[:stock_levels][params['SellerSKU']] = params['TotalSupplyQuantity'].to_i
+          response[:stock_levels][params['SellerSKU']] = params['InStockSupplyQuantity'].to_i
         end
         
         next_token = REXML::XPath.first(document, '//NextToken')

--- a/test/remote/amazon_mws_test.rb
+++ b/test/remote/amazon_mws_test.rb
@@ -69,7 +69,7 @@ class RemoteAmazonMarketplaceWebservicesTest < Test::Unit::TestCase
   end
 
   def test_list_inventory
-    response = @service.fetch_stock_levels(:start_time => Time.new('2010-01-01'))
+    response = @service.fetch_stock_levels(:start_time => Time.parse('2010-01-01'))
     assert response.success?
     assert_equal 0, response.stock_levels['SETTLERS']
   end

--- a/test/unit/services/amazon_mws_test.rb
+++ b/test/unit/services/amazon_mws_test.rb
@@ -182,7 +182,7 @@ class AmazonMarketplaceWebServiceTest < Test::Unit::TestCase
     response = @service.fetch_stock_levels
     assert response.success?
     assert_equal 202, response.stock_levels['GN-00-01A']
-    assert_equal 240, response.stock_levels['GN-00-02A']
+    assert_equal 199, response.stock_levels['GN-00-02A']
   end
 
   def test_get_inventory_multipage
@@ -194,9 +194,9 @@ class AmazonMarketplaceWebServiceTest < Test::Unit::TestCase
     response = @service.fetch_stock_levels
     assert response.success?
     assert_equal 202, response.stock_levels['GN-00-01A']
-    assert_equal 240, response.stock_levels['GN-00-02A']
-    assert_equal 123, response.stock_levels['GN-01-01A']
-    assert_equal 321, response.stock_levels['GN-01-02A']
+    assert_equal 199, response.stock_levels['GN-00-02A']
+    assert_equal 0, response.stock_levels['GN-01-01A']
+    assert_equal 5259, response.stock_levels['GN-01-02A']
   end
 
   def test_fetch_tracking_numbers


### PR DESCRIPTION
from the Amazon response which would report incorrect inventory
counts.

Also fixed a small date issue with one of the remote tests.

Please review @jduff @soleone
