### PR TITLE
Add order note if present for Shipwire fulfillments

### DIFF
--- a/lib/active_fulfillment/fulfillment/services/shipwire.rb
+++ b/lib/active_fulfillment/fulfillment/services/shipwire.rb
@@ -133,6 +133,9 @@ module ActiveMerchant
           Array(line_items).each_with_index do |line_item, index|
             add_item(xml, line_item, index)
           end
+          xml.tag! 'Note' do
+            xml.cdata! options[:note] unless options[:note].blank?
+          end
         end
       end
 

--- a/test/unit/services/shipwire_test.rb
+++ b/test/unit/services/shipwire_test.rb
@@ -157,6 +157,19 @@ class ShipwireTest < Test::Unit::TestCase
     assert_equal 'MyCorp', company_node.text 
   end
 
+  def test_order_excludes_note_by_default
+    xml = REXML::Document.new(@shipwire.send(:build_fulfillment_request, '123456', @address, @line_items, @options))
+    note_node = REXML::XPath.first(xml, "//Note").cdatas.first
+    assert_nil note_node
+  end
+
+  def test_order_includes_note_when_present
+    @options[:note] = "A test note"
+    xml = REXML::Document.new(@shipwire.send(:build_fulfillment_request, '123456', @address, @line_items, @options))
+    note_node = REXML::XPath.first(xml, "//Note").cdatas.first
+    assert_equal "A test note", note_node.to_s
+  end
+
   private
   def successful_empty_tracking_response
     "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<TrackingUpdateResponse><Status>Test</Status><TotalOrders></TotalOrders><TotalShippedOrders></TotalShippedOrders><TotalProducts></TotalProducts><Bookmark></Bookmark></TrackingUpdateResponse>"


### PR DESCRIPTION
## Changes

This adds a note to the Order xml as a CDATA element when provided with a note in the options hash. Has tests for when options[:note] is and isn't set.
## Review

@Soleone @jduff
