### PR TITLE
Shipwire: Fix parsing error message from CDATA on failed requests

### DIFF
--- a/lib/active_fulfillment/fulfillment/services/shipwire.rb
+++ b/lib/active_fulfillment/fulfillment/services/shipwire.rb
@@ -27,7 +27,7 @@ module ActiveMerchant
                      'UK'  => 'United Kingdom'
                    }
                    
-      INVALID_LOGIN = /Error with Valid Username\/EmailAddress and Password Required/
+      INVALID_LOGIN = /(Error with Valid Username\/EmailAddress and Password Required)|(Could not verify Username\/EmailAddress and Password combination)/
 
       class_attribute :affiliate_id
 
@@ -193,7 +193,7 @@ module ActiveMerchant
         
         document = REXML::Document.new(xml)
         document.root.elements.each do |node|
-          response[node.name.underscore.to_sym] = node.text
+          response[node.name.underscore.to_sym] = text_content(node)
         end
         
         response[:success] = response[:status] == '0'
@@ -214,7 +214,7 @@ module ActiveMerchant
             amount = to_check.sum { |a| node.attributes[a].to_i }
             response[:stock_levels][node.attributes['code']] = amount
           else
-            response[node.name.underscore.to_sym] = node.text
+            response[node.name.underscore.to_sym] = text_content(node)
           end
         end
         
@@ -237,7 +237,7 @@ module ActiveMerchant
               response[:tracking_numbers][node.attributes['id']] = tracking_number
             end
           else
-            response[node.name.underscore.to_sym] = node.text
+            response[node.name.underscore.to_sym] = text_content(node)
           end
         end
         
@@ -249,6 +249,12 @@ module ActiveMerchant
       def message_from(string)
         return if string.blank?
         string.gsub("\n", '').squeeze(" ")
+      end
+
+      def text_content(xml_node)
+        text = xml_node.text
+        text = xml_node.cdatas.join if text.blank?
+        text
       end
     end
   end

--- a/test/fixtures/xml/shipwire/fulfillment_failure_response.xml
+++ b/test/fixtures/xml/shipwire/fulfillment_failure_response.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE SubmitOrderResponse SYSTEM "http://www.shipwire.com/exec/download/SubmitOrderResponse.dtd">
+<SubmitOrderResponse>
+  <Status>Error</Status>
+  <ErrorMessage>
+    <![CDATA[Could not verify Username/EmailAddress and Password combination]]>
+</ErrorMessage>
+</SubmitOrderResponse>

--- a/test/unit/services/shipwire_test.rb
+++ b/test/unit/services/shipwire_test.rb
@@ -170,6 +170,11 @@ class ShipwireTest < Test::Unit::TestCase
     assert_equal "A test note", note_node.to_s
   end
 
+  def test_error_response_cdata_parsing
+    @shipwire.expects(:ssl_post).returns(xml_fixture('shipwire/fulfillment_failure_response'))
+    assert !@shipwire.valid_credentials?
+  end
+
   private
   def successful_empty_tracking_response
     "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<TrackingUpdateResponse><Status>Test</Status><TotalOrders></TotalOrders><TotalShippedOrders></TotalShippedOrders><TotalProducts></TotalProducts><Bookmark></Bookmark></TrackingUpdateResponse>"


### PR DESCRIPTION
Merchants' fulfillment requests were failing but they didn't receive any error message (was blank). This made it look like an issue with the integration but was actually just an issue of incorrect credentials.

The problem is that Shipwire apparently recently changed their error responses to both use a new message (not sure if old one is still used for different type of failures/requests) and put it inside of a CDATA block.

We failed to parse that properly from a CDATA node and only looked at the text node.

Please review @jduff 
