### PR TITLE
Migrates test suite over to minitest 5.0

### DIFF
--- a/active_fulfillment.gemspec
+++ b/active_fulfillment.gemspec
@@ -66,5 +66,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha')
   s.add_development_dependency('rdoc', '>= 2.4.2')
+  s.add_development_dependency('minitest', '>= 5.0.0')
 end
 

--- a/test/remote/amazon_mws_test.rb
+++ b/test/remote/amazon_mws_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteAmazonMarketplaceWebservicesTest < Test::Unit::TestCase
+class RemoteAmazonMarketplaceWebservicesTest < ActiveMerchant::Fulfillment::Test
 
   def setup
     @service = AmazonMarketplaceWebService.new( fixtures(:amazon_mws) )

--- a/test/remote/amazon_test.rb
+++ b/test/remote/amazon_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteAmazonTest < Test::Unit::TestCase
+class RemoteAmazonTest < ActiveMerchant::Fulfillment::Test
   # In order for these tests to work you must have a live account with Amazon.
   # You can sign up at http://amazonservices.com/fulfillment/
   # The SKUs must also exist in your inventory. You do not want the SKUs you

--- a/test/remote/shipwire_test.rb
+++ b/test/remote/shipwire_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteShipwireTest < Test::Unit::TestCase
+class RemoteShipwireTest < ActiveMerchant::Fulfillment::Test
   def setup
     Base.mode = :test
 
@@ -94,7 +94,7 @@ class RemoteShipwireTest < Test::Unit::TestCase
     
     assert response.success?
     assert response.test?
-    assert_not_nil response.params['transaction_id']
+    assert response.params['transaction_id'], 'transaction_id should not be nil'
     assert_equal "1", response.params['total_orders']
     assert_equal "0", response.params['total_items']
     assert_equal "0", response.params['status']

--- a/test/remote/webgistix_test.rb
+++ b/test/remote/webgistix_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteWebgistixTest < Test::Unit::TestCase
+class RemoteWebgistixTest < ActiveMerchant::Fulfillment::Test
   def setup
     Base.mode = :test
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,49 +5,49 @@ require 'rubygems'
 require 'bundler'
 Bundler.setup
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'digest/md5'
 require 'active_fulfillment'
 require 'active_utils'
 
-require 'mocha'
+require 'mocha/setup'
 
-module Test
-  module Unit
-    class TestCase
-      include ActiveMerchant::Fulfillment
-      
-      LOCAL_CREDENTIALS = ENV['HOME'] + '/.active_merchant/fixtures.yml' unless defined?(LOCAL_CREDENTIALS)
-      DEFAULT_CREDENTIALS = File.dirname(__FILE__) + '/fixtures.yml' unless defined?(DEFAULT_CREDENTIALS)
+module Minitest
+  class Test
+    include ActiveMerchant::Fulfillment
+    
+    LOCAL_CREDENTIALS = ENV['HOME'] + '/.active_merchant/fixtures.yml' unless defined?(LOCAL_CREDENTIALS)
+    DEFAULT_CREDENTIALS = File.dirname(__FILE__) + '/fixtures.yml' unless defined?(DEFAULT_CREDENTIALS)
 
-      def all_fixtures
-        @@fixtures ||= load_fixtures
-      end
+    def all_fixtures
+      @@fixtures ||= load_fixtures
+    end
+    
+    def fixtures(key)
+      data = all_fixtures[key] || raise(StandardError, "No fixture data was found for '#{key}'")
       
-      def fixtures(key)
-        data = all_fixtures[key] || raise(StandardError, "No fixture data was found for '#{key}'")
-        
-        data.dup
-      end
-          
-      def load_fixtures
-        file = File.exists?(LOCAL_CREDENTIALS) ? LOCAL_CREDENTIALS : DEFAULT_CREDENTIALS
-        yaml_data = YAML.load(File.read(file))
-        symbolize_keys(yaml_data)
+      data.dup
+    end
+    
+    def load_fixtures
+      file = File.exists?(LOCAL_CREDENTIALS) ? LOCAL_CREDENTIALS : DEFAULT_CREDENTIALS
+      yaml_data = YAML.load(File.read(file))
+      symbolize_keys(yaml_data)
       
-        yaml_data
-      end
+      yaml_data
+    end
 
-      def xml_fixture(path) # where path is like 'usps/beverly_hills_to_ottawa_response'
-        open(File.join(File.dirname(__FILE__),'fixtures','xml',"#{path}.xml")) {|f| f.read}
-      end
+    def xml_fixture(path) # where path is like 'usps/beverly_hills_to_ottawa_response'
+      open(File.join(File.dirname(__FILE__),'fixtures','xml',"#{path}.xml")) {|f| f.read}
+    end
+    
+    def symbolize_keys(hash)
+      return unless hash.is_a?(Hash)
       
-      def symbolize_keys(hash)
-        return unless hash.is_a?(Hash)
-        
-        hash.symbolize_keys!
-        hash.each{|k,v| symbolize_keys(v)}
-      end
+      hash.symbolize_keys!
+      hash.each{|k,v| symbolize_keys(v)}
     end
   end
 end
+
+class ActiveMerchant::Fulfillment::Test < Minitest::Test; end

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class BaseTest < Test::Unit::TestCase
+class BaseTest < ActiveMerchant::Fulfillment::Test
   include ActiveMerchant::Fulfillment
 
   def test_get_shipwire_by_string
@@ -12,6 +12,6 @@ class BaseTest < Test::Unit::TestCase
   end
   
   def test_get_unknown_service
-    assert_raise(NameError){ Base.service(:polar_north) }
+    assert_raises(NameError){ Base.service(:polar_north) }
   end
 end

--- a/test/unit/services/amazon_mws_test.rb
+++ b/test/unit/services/amazon_mws_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class AmazonMarketplaceWebServiceTest < Test::Unit::TestCase
+class AmazonMarketplaceWebServiceTest < ActiveMerchant::Fulfillment::Test
   def setup
     @service = AmazonMarketplaceWebService.new(
                                                :login => 'l',
@@ -163,12 +163,12 @@ class AmazonMarketplaceWebServiceTest < Test::Unit::TestCase
 
   def test_missing_order_date
     @options.delete(:order_date)
-    assert_raise(ArgumentError) { @service.fulfill('12345678', @address, @line_items, @options) }
+    assert_raises(ArgumentError) { @service.fulfill('12345678', @address, @line_items, @options) }
   end
 
   def test_missing_shipping_method
     @options.delete(:shipping_method)
-    assert_raise(ArgumentError) { @service.fulfill('12345678', @address, @line_items, @options) }
+    assert_raises(ArgumentError) { @service.fulfill('12345678', @address, @line_items, @options) }
   end
 
   def test_get_service_status
@@ -283,9 +283,7 @@ class AmazonMarketplaceWebServiceTest < Test::Unit::TestCase
 
   def test_building_address_skips_nil_values
     @address[:address2] = nil
-    assert_nothing_raised do
-      @service.send(:build_address, @address)
-    end
+    @service.send(:build_address, @address)
   end
 
   def test_building_a_full_query_does_not_cause_query_to_fail

--- a/test/unit/services/amazon_test.rb
+++ b/test/unit/services/amazon_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class AmazonTest < Test::Unit::TestCase
+class AmazonTest < ActiveMerchant::Fulfillment::Test
    def setup
      @service = AmazonService.new(
                   :login => 'l',
@@ -46,17 +46,17 @@ class AmazonTest < Test::Unit::TestCase
   
   def test_missing_order_comment
     @options.delete(:comment)
-    assert_raise(ArgumentError) { @service.fulfill('12345678', @address, @line_items, @options) }
+    assert_raises(ArgumentError) { @service.fulfill('12345678', @address, @line_items, @options) }
   end
   
   def test_missing_order_date
     @options.delete(:order_date)
-    assert_raise(ArgumentError) { @service.fulfill('12345678', @address, @line_items, @options) }
+    assert_raises(ArgumentError) { @service.fulfill('12345678', @address, @line_items, @options) }
   end
   
   def test_missing_shipping_method
     @options.delete(:shipping_method)
-    assert_raise(ArgumentError) { @service.fulfill('12345678', @address, @line_items, @options) }
+    assert_raises(ArgumentError) { @service.fulfill('12345678', @address, @line_items, @options) }
   end
 
   def test_get_inventory

--- a/test/unit/services/shipwire_test.rb
+++ b/test/unit/services/shipwire_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ShipwireTest < Test::Unit::TestCase
+class ShipwireTest < ActiveMerchant::Fulfillment::Test
   def setup
     Base.mode = :test
     
@@ -29,30 +29,28 @@ class ShipwireTest < Test::Unit::TestCase
   end 
   
   def test_missing_login
-    assert_raise(ArgumentError) do
+    assert_raises(ArgumentError) do
       ShipwireService.new(:password => 'test')
     end
   end
   
   def test_missing_password
-    assert_raise(ArgumentError) do
+    assert_raises(ArgumentError) do
       ShipwireService.new(:login => 'cody')
     end
   end
   
   def test_missing_credentials
-    assert_raise(ArgumentError) do
+    assert_raises(ArgumentError) do
       ShipwireService.new(:password => 'test')
     end
   end
   
   def test_credentials_present
-    assert_nothing_raised do
-      ShipwireService.new(
-        :login    => 'cody',
-        :password => 'test'
+    assert ShipwireService.new(
+      :login    => 'cody',
+      :password => 'test'
       )
-    end
   end
   
   def test_country_format

--- a/test/unit/services/webgistix_test.rb
+++ b/test/unit/services/webgistix_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class WebgistixTest < Test::Unit::TestCase
+class WebgistixTest < ActiveMerchant::Fulfillment::Test
    def setup
      Base.mode = :test
      
@@ -30,30 +30,28 @@ class WebgistixTest < Test::Unit::TestCase
   end 
   
   def test_missing_login
-    assert_raise(ArgumentError) do
+    assert_raises(ArgumentError) do
       WebgistixService.new(:password => 'test')
     end
   end
   
   def test_missing_password
-    assert_raise(ArgumentError) do
+    assert_raises(ArgumentError) do
       WebgistixService.new(:login => 'cody')
     end
   end
   
   def test_missing_credentials
-    assert_raise(ArgumentError) do
+    assert_raises(ArgumentError) do
       WebgistixService.new(:password => 'test')
     end
   end
   
   def test_credentials_present
-    assert_nothing_raised do
-      WebgistixService.new(
-        :login    => 'cody',
-        :password => 'test'
+    assert WebgistixService.new(
+      :login    => 'cody',
+      :password => 'test'
       )
-    end
   end
   
   def test_successful_fulfillment


### PR DESCRIPTION
Also adds a test wrapper class so if we ever switch again we'll only
need to change that code in a single place instead of each file.

Since we are using Minitest in various other places it only makes sense to get consistent in our various projects.

Please review @jduff @daverooneyca
