### PR TITLE
Allow usage along activesupport-4

### DIFF
--- a/active_fulfillment.gemspec
+++ b/active_fulfillment.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.date = %q{2010-12-13}
   s.email = %q{cody@shopify.com}
 
-  s.files       = Dir.glob("{lib}/**/*") + %w(VERSION CHANGELOG)
+  s.files       = Dir.glob("{lib}/**/*") + %w(CHANGELOG)
   s.test_files  = Dir.glob("{test}/**/*")
 
   s.homepage = %q{http://github.com/shopify/active_fulfillment}
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.3.7}
   s.summary = %q{Framework and tools for dealing with shipping, tracking and order fulfillment services.}
 
-  s.add_dependency('activesupport', '~> 3.2.9')
+  s.add_dependency('activesupport', '>= 3.2.9')
   s.add_dependency('builder', '>= 2.0.0')
   s.add_dependency('active_utils', '>= 1.0.1')
 

--- a/lib/active_fulfillment.rb
+++ b/lib/active_fulfillment.rb
@@ -23,6 +23,7 @@
 
 require 'active_support'
 require 'active_support/core_ext/class/attribute'
+require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/class/delegating_attributes'
 require 'active_support/core_ext/time/calculations'
 require 'active_support/core_ext/date/calculations'


### PR DESCRIPTION
It was just matter of changing gem specification, and require an activesupport module that was previously implicitly loaded.
