### PR TITLE
upcase amazon postcode so they can read it

### DIFF
--- a/lib/active_fulfillment/fulfillment/services/amazon.rb
+++ b/lib/active_fulfillment/fulfillment/services/amazon.rb
@@ -263,7 +263,7 @@ module ActiveMerchant
           xml.tag! 'City', address[:city]
           xml.tag! 'StateOrProvinceCode', address[:state]
           xml.tag! 'CountryCode', address[:country]
-          xml.tag! 'PostalCode', address[:zip].upcase
+          xml.tag! 'PostalCode', address[:zip]
           xml.tag! 'PhoneNumber', address[:phone]  unless address[:phone].blank?
         end
       end

--- a/lib/active_fulfillment/fulfillment/services/amazon_mws.rb
+++ b/lib/active_fulfillment/fulfillment/services/amazon_mws.rb
@@ -400,6 +400,7 @@ module ActiveMerchant
 
       def build_address(address)
         requires!(address, :name, :address1, :city, :state, :country, :zip)
+        address[:zip].upcase!
         ary = address.map{ |key, value| [LOOKUPS[:destination_address][key], value] if LOOKUPS[:destination_address].include?(key) && value.present? }
         Hash[ary.compact]
       end

--- a/test/unit/services/amazon_mws_test.rb
+++ b/test/unit/services/amazon_mws_test.rb
@@ -23,6 +23,17 @@ class AmazonMarketplaceWebServiceTest < Test::Unit::TestCase
       :zip => '90210',
       :phone => "(555)555-5555"
     }
+
+    @canadian_address = { 
+      :name => 'Johnny Bouchard',
+      :address1 => '100 Canuck St',
+      :address2 => 'Room 56',
+      :city => 'Ottawa',
+      :state => 'ON',
+      :country => 'CA',
+      :zip => 'h0h0h0',
+      :phone => "(555)555-5555"
+    }
     
     @line_items = [
                    { :sku => 'SETTLERS1',
@@ -108,6 +119,11 @@ class AmazonMarketplaceWebServiceTest < Test::Unit::TestCase
       "DestinationAddress.PhoneNumber" => @address[:phone]
     }
     assert_equal expected_items, @service.build_address(@address)
+  end
+
+  def test_build_address_upcases_postal_code
+    address = @service.build_address(@canadian_address)
+    assert_equal address["DestinationAddress.PostalCode"], "H0H0H0" 
   end
 
   def test_build_address_with_missing_fields


### PR DESCRIPTION
Amazon is apparently set up to only parse postal codes that are in all caps.  This has caused them some troubles recently, so I'm just setting postal codes to send UPCASE.

@csaunders 
@pickle27 
