### PR TITLE
Update Shipwire's tracking_companies to match others

### DIFF
--- a/lib/active_fulfillment/fulfillment/services/shipwire.rb
+++ b/lib/active_fulfillment/fulfillment/services/shipwire.rb
@@ -238,7 +238,7 @@ module ActiveMerchant
               response[:tracking_numbers][node.attributes['id']] = [tracking_number]
 
               tracking_company = node.elements['TrackingNumber'].attributes['carrier']
-              response[:tracking_companies][node.attributes['id']] = tracking_company.strip if tracking_company
+              response[:tracking_companies][node.attributes['id']] = [tracking_company.strip] if tracking_company
 
               tracking_url = node.elements['TrackingNumber'].attributes['href']
               response[:tracking_urls][node.attributes['id']] = [tracking_url.strip] if tracking_url
@@ -266,5 +266,3 @@ module ActiveMerchant
     end
   end
 end
-
-

--- a/test/unit/services/shipwire_test.rb
+++ b/test/unit/services/shipwire_test.rb
@@ -146,7 +146,7 @@ class ShipwireTest < Test::Unit::TestCase
     assert_equal "1", response.params["total_shipped_orders"]
 
     assert_equal ["9400110200793596422990"], response.tracking_numbers["40298"]
-    assert_equal "USPS", response.tracking_companies["40298"]
+    assert_equal ["USPS"], response.tracking_companies["40298"]
     assert_equal ["http://trkcnfrm1.smi.usps.com/PTSInternetWeb/InterLabelInquiry.do?origTrackNum=9400110200793596422990"], response.tracking_urls["40298"]
   end
 


### PR DESCRIPTION
Webgistix and AmazonMWS responses have `tracking_companies` set to a hash with array values, whereas Shipwire returns a hash with string values.

Relevant code:
- [Shipwire](https://github.com/Shopify/active_fulfillment/blob/master/lib/active_fulfillment/fulfillment/services/shipwire.rb#L227)
- [AmazonMWS](https://github.com/Shopify/active_fulfillment/blob/2e52c43b586d79af9fa543fde0487fc8001eef92/lib/active_fulfillment/fulfillment/services/amazon_mws.rb#L245)
- [Webgistix](https://github.com/Shopify/active_fulfillment/blob/2e52c43b586d79af9fa543fde0487fc8001eef92/lib/active_fulfillment/fulfillment/services/webgistix.rb#L316-L317)

Ping @pickle27 
