### PR TITLE
Stricter active_utils dependency

### DIFF
--- a/active_fulfillment.gemspec
+++ b/active_fulfillment.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activesupport', '>= 3.2.9')
   s.add_dependency('builder', '>= 2.0.0')
-  s.add_dependency('active_utils', '>= 1.0.1')
+  s.add_dependency('active_utils', '~> 2.2.0')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha')


### PR DESCRIPTION
We shouldn't be relying on the latest {major,minor} version of
active_utils, but instead the latest patch version

@jamesmacaulay 
