### PR TITLE
Fail fetch_stock_levels when stock_level retrieval via tokens fails mid-process

### DIFF
--- a/lib/active_fulfillment/fulfillment/services/amazon_mws.rb
+++ b/lib/active_fulfillment/fulfillment/services/amazon_mws.rb
@@ -139,6 +139,8 @@ module ActiveMerchant
         while token = response.params['next_token'] do
           next_page = commit :post, :inventory, :list_next, build_next_inventory_list_request(token)
 
+          # if we fail during the stock-level-via-token gathering, fail the whole request
+          return next_page if next_page.params['response_status'] != SUCCESS
           next_page.stock_levels.merge!(response.stock_levels)
           response = next_page
         end


### PR DESCRIPTION
Receiving the exception "NoMethodError: undefined method `stock_levels'" when requests to Amazon fail retrieving stock levels using tokens.  This fails the whole request, instead of throwing an exception in the middle.
