### PR TITLE
Adds order_names field and includes appropriate deprecation error

### DIFF
--- a/lib/active_fulfillment/fulfillment/services/shopify_api.rb
+++ b/lib/active_fulfillment/fulfillment/services/shopify_api.rb
@@ -2,8 +2,6 @@ module ActiveMerchant
   module Fulfillment
     class ShopifyAPIService < Service
 
-      class DeprecationError < StandardError; end
-
       OrderIdCutoffDate = Date.iso8601("2015-03-01")
 
       RESCUABLE_CONNECTION_ERRORS = [
@@ -52,8 +50,6 @@ module ActiveMerchant
       end
 
       def fetch_tracking_data(order_numbers, options = {})
-        raise DeprecationError, "order_ids should no longer be included in API requests" if Time.now.to_date >= OrderIdCutoffDate && ENV['active_fulfillment_test']
-
         options.merge!({:order_ids => order_numbers, :order_names => order_numbers})
         response = send_app_request('fetch_tracking_numbers', options.delete(:headers), options)
         if response

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,7 +15,6 @@ require 'mocha/setup'
 
 require 'logger'
 ActiveMerchant::Fulfillment::Service.logger = Logger.new(nil)
-ENV['active_fulfillment_test'] = '1'
 
 module Test
   module Unit

--- a/test/unit/services/shopify_api_test.rb
+++ b/test/unit/services/shopify_api_test.rb
@@ -64,17 +64,6 @@ class ShopifyAPITest < Test::Unit::TestCase
     assert_equal expected, service.fetch_stock_levels().stock_levels
   end
 
-  def test_tracking_data_request_deprecation_when_order_ids_included_and_past_deprecation_date
-    Timecop.freeze(ShopifyAPIService::OrderIdCutoffDate) do
-      assert_raises ShopifyAPIService::DeprecationError do
-        service = build_service(format: 'xml')
-        xml = '<TrackingNumbers><Order><ID>123</ID><Tracking>abc</Tracking></Order><Order><ID>456</ID><Tracking>def</Tracking></Order></TrackingNumbers>'
-        service.stubs(:send_app_request).with('fetch_tracking_numbers', nil, {order_ids: [1, 2, 4], order_names: [1, 2, 4]}).returns(xml)
-        service.fetch_tracking_data([1, 2, 4]).tracking_numbers
-      end
-    end
-  end
-
   def test_parse_tracking_data_response_parses_xml_correctly
     service = build_service(format: 'xml')
     xml = '<TrackingNumbers><Order><ID>123</ID><Tracking>abc</Tracking></Order><Order><ID>456</ID><Tracking>def</Tracking></Order></TrackingNumbers>'
@@ -83,6 +72,9 @@ class ShopifyAPITest < Test::Unit::TestCase
 
     mock_app_request('fetch_tracking_numbers', request_params, xml)
     assert_equal expected, service.fetch_tracking_data([1,2,4]).tracking_numbers
+
+    after_deprecation = Time.now.to_date >= ShopifyAPIService::OrderIdCutoffDate
+    flunk "The request params should no longer include 'order_ids'" if after_deprecation
   end
 
   def test_parse_stock_level_response_parses_json_with_root_correctly


### PR DESCRIPTION
This adds `order_names` to the generated API requests. The previous field of `order_ids` is now deprecated and will be removed on or after the 1st of March, 2015.

The reason for this is simply because the actual value that is being passed to consumers of the [FulfillmentServices API](http://docs.shopify.com/api/fulfillmentservice) aren't getting Order IDs but actually Order Names (i.e. `#SHOP-ORDER-123`) as they appear in the Admin.

For compatibility reasons we'll include both in the request until the deprecation date. The deprecation will only trigger during testing in order to prevent arbitrary downtime if the gem doesn't get updated before then.

Please review @jamesmacaulay @pickle27 @fw42 
