### PR TITLE
Change amazon_request? parameters and use constant-time string comparison.

### DIFF
--- a/test/unit/services/amazon_mws_test.rb
+++ b/test/unit/services/amazon_mws_test.rb
@@ -116,9 +116,16 @@ class AmazonMarketplaceWebServiceTest < Minitest::Test
 
   def test_verify_amazon_response
     service = ActiveFulfillment::AmazonMarketplaceWebService.new(:login => "AKIAFJPPO5KLY6G4XO7Q", :password => "aaa")
-    string_signed_by_amazon = "POST\nhttps://www.vendor.com/mwsApp1\n/orders/listRecentOrders.jsp?sessionId=123"
-    string_signed_by_amazon += "\nAWSAccessKeyId=AKIAFJPPO5KLY6G4XO7Q&Marketplace=ATVPDKIKX0DER&Merchant=A047950713KM6AGKQCBRD&SignatureMethod=HmacSHA256&SignatureVersion=2"
-    assert service.amazon_request?(string_signed_by_amazon, "b0hxWov1RfBOqNk77UDfNRRZmf3tkdM7vuNa%2FolfnWg%3D")
+    post_params = {
+      AWSAccessKeyId: "AKIAFJPPO5KLY6G4XO7Q",
+      Marketplace: "ATVPDKIKX0DER",
+      Merchant: "A047950713KM6AGKQCBRD",
+      SignatureMethod: "HmacSHA256",
+      SignatureVersion: "2",
+      Signature: "b0hxWov1RfBOqNk77UDfNRRZmf3tkdM7vuNa/olfnWg=",
+      SignedString: "This should be ignored."
+    }
+    assert service.amazon_request?("POST", "https://www.vendor.com/mwsApp1", "/orders/listRecentOrders.jsp?sessionId=123", post_params)
   end
 
   def test_build_address


### PR DESCRIPTION
For review @csaunders @EiNSTeiN-
/cc @Shopify/security

This is the active_fulfillment change corresponding to https://github.com/Shopify/shopify/pull/48258. I've changed `amazon_request?` to accept the signed parameters individually so the caller doesn't need to know the details of Amazon's signature mechanism (sorting parameters, excluding the signature itself, etc.), and switched to constant-time string comparison to prevent timing attacks.

The change to `amazon_request?` breaks compatibility, but I think that's okay since this is going into an upcoming 3.0.0 release.

This change was experimentally deployed to Shopify as part of https://github.com/Shopify/shopify/pull/48258. The first MWS signup just went through and no signature errors were reported. So it appears the validation is working correctly, but I'll wait for some more signups to go through before merging just in case.