### PR TITLE
Amazon MWS name length

### DIFF
--- a/lib/active_fulfillment/services/amazon_mws.rb
+++ b/lib/active_fulfillment/services/amazon_mws.rb
@@ -423,6 +423,7 @@ module ActiveFulfillment
       address[:state] ||= "N/A"
       address[:zip].upcase!
       address[:name] = "#{address[:company]} - #{address[:name]}" if address[:company].present?
+      address[:name] = address[:name][0...50] if address[:name].present?
       ary = address.map{ |key, value| [LOOKUPS[:destination_address][key], value] if LOOKUPS[:destination_address].include?(key) && value.present? }
       Hash[ary.compact]
     end

--- a/lib/active_fulfillment/version.rb
+++ b/lib/active_fulfillment/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module ActiveFulfillment
-  VERSION = "3.0.0.pre1"
+  VERSION = "3.0.0.pre2"
 end

--- a/test/unit/services/amazon_mws_test.rb
+++ b/test/unit/services/amazon_mws_test.rb
@@ -38,6 +38,18 @@ class AmazonMarketplaceWebServiceTest < Minitest::Test
       :phone => "(555)555-5555"
     }
 
+    @long_address = {
+      :name => 'Mister Long Name The Third',
+      :company => 'Company Overflow Name Incorporated LLC',
+      :address1 => '100 Information Super Highway',
+      :address2 => 'Suite 66',
+      :city => 'Beverly Hills',
+      :state => 'CA',
+      :country => 'US',
+      :zip => '90210',
+      :phone => "(555)555-5555"
+    }
+
     @canadian_address = {
       :name => 'Johnny Bouchard',
       :address1 => '100 Canuck St',
@@ -156,6 +168,10 @@ class AmazonMarketplaceWebServiceTest < Minitest::Test
     assert_equal expected_items, @service.build_address(@commercial_address)
   end
 
+  def test_build_address_truncates_name_to_length
+    assert_equal "Company Overflow Name Incorporated LLC - Mister Lo", @service.build_address(@long_address)["DestinationAddress.Name"]
+  end
+
   def test_build_address_upcases_postal_code
     address = @service.build_address(@canadian_address)
     assert_equal address["DestinationAddress.PostalCode"], "H0H0H0"
@@ -247,7 +263,7 @@ class AmazonMarketplaceWebServiceTest < Minitest::Test
 
   def test_get_inventory
     @service.expects(:ssl_post).returns(xml_fixture('amazon_mws/inventory_list_inventory_supply'))
-    
+
     @service.class.logger.expects(:info).with do |message|
       assert_match /ListInventorySupplyResult/, message
       assert /MWSAuthToken/ !~ message


### PR DESCRIPTION
@garethson @kevinhughes27 @RichardBlair 
cc @AyalS 

The API expects the destination address name to be 50 characters or less:
![screen shot 2015-08-04 at 11 29 26 am](https://cloud.githubusercontent.com/assets/84159/9064811/38344a54-3a9c-11e5-834b-f5d206add02f.png)

Truncate if it is too long. Bump version to `3.0.0.pre2`.
