### PR TITLE
Address without zip

### DIFF
--- a/lib/active_fulfillment/services/amazon_mws.rb
+++ b/lib/active_fulfillment/services/amazon_mws.rb
@@ -421,7 +421,7 @@ module ActiveFulfillment
     def build_address(address)
       requires!(address, :name, :address1, :city, :country, :zip)
       address[:state] ||= "N/A"
-      address[:zip].upcase!
+      address[:zip].upcase! if address[:zip]
       address[:name] = "#{address[:company]} - #{address[:name]}" if address[:company].present?
       address[:name] = address[:name][0...50] if address[:name].present?
       ary = address.map{ |key, value| [LOOKUPS[:destination_address][key], value] if LOOKUPS[:destination_address].include?(key) && value.present? }

--- a/lib/active_fulfillment/version.rb
+++ b/lib/active_fulfillment/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module ActiveFulfillment
-  VERSION = "3.0.0.pre2"
+  VERSION = "3.0.0.pre3"
 end

--- a/test/unit/services/amazon_mws_test.rb
+++ b/test/unit/services/amazon_mws_test.rb
@@ -154,6 +154,20 @@ class AmazonMarketplaceWebServiceTest < Minitest::Test
     assert_equal expected_items, @service.build_address(@address)
   end
 
+  def test_build_address_without_zip
+    expected_items = {
+      "DestinationAddress.Name" => @address[:name],
+      "DestinationAddress.Line1" => @address[:address1],
+      "DestinationAddress.Line2" => @address[:address2],
+      "DestinationAddress.City" => @address[:city],
+      "DestinationAddress.StateOrProvinceCode" => @address[:state],
+      "DestinationAddress.CountryCode" => @address[:country],
+      "DestinationAddress.PhoneNumber" => @address[:phone]
+    }
+    @address[:zip] = nil
+    assert_equal expected_items, @service.build_address(@address)
+  end
+
   def test_build_address_attaches_company_name_to_name
     expected_items = {
       "DestinationAddress.Name" => "#{@commercial_address[:company]} - #{@commercial_address[:name]}",


### PR DESCRIPTION
@garethson @tjoyal 

Guard against an address missing a zip. If it is required, let the service error as expected. Don't error in some internal call to `.upcase!`