### PR TITLE
Allow throttling Amazon GetFulfillmentOrder.

### DIFF
--- a/lib/active_fulfillment/version.rb
+++ b/lib/active_fulfillment/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module ActiveFulfillment
-  VERSION = "3.0.0.pre3"
+  VERSION = "3.0.0.pre4"
 end


### PR DESCRIPTION
Allow very simple throttle options when fetching tracking data via `{throttle: {interval: 10, sleep_time: 1}}`.

@kmcphillips @jnormore 