### PR TITLE
Allow to use this gem with Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
 language: ruby
 script: bundle exec rake
 sudo: false
+cache: bundler
 
 rvm:
-- "2.0"
-- "2.1"
-- "2.2"
+- 2.0
+- 2.1
+- 2.2.3
 
 gemfile:
 - Gemfile.activesupport32
 - Gemfile.activesupport40
 - Gemfile.activesupport41
 - Gemfile.activesupport42
+- Gemfile.activesupport5
+
+matrix:
+  exclude:
+    - rvm: 2.0
+      gemfile: Gemfile.activesupport5
+    - rvm: 2.1
+      gemfile: Gemfile.activesupport5

--- a/Gemfile.activesupport5
+++ b/Gemfile.activesupport5
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gemspec
+
+gem 'activesupport', github: 'rails/rails'

--- a/lib/active_fulfillment.rb
+++ b/lib/active_fulfillment.rb
@@ -24,7 +24,6 @@
 require 'active_support'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/module/attribute_accessors'
-require 'active_support/core_ext/class/delegating_attributes'
 require 'active_support/core_ext/time/calculations'
 require 'active_support/core_ext/date/calculations'
 require 'active_support/core_ext/numeric/time'


### PR DESCRIPTION
The only required change was to remove an unused require that was removed from Rails 5.

Review @garethson