### PR TITLE
Remove REXML Require from Runtime

### DIFF
--- a/lib/active_fulfillment.rb
+++ b/lib/active_fulfillment.rb
@@ -36,7 +36,6 @@ end
 require 'builder'
 require 'cgi'
 require 'net/https'
-require 'rexml/document'
 require 'nokogiri'
 require 'active_utils'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require 'active_fulfillment'
 require 'minitest/autorun'
 require 'mocha/setup'
 require 'timecop'
+require 'rexml/document'
 
 require 'logger'
 ActiveFulfillment::Service.logger = Logger.new(nil)


### PR DESCRIPTION
As we converted all the services that used rexml for nokogiri. 

We can now remove the require from runtime.

We still need it in tests as they are not converted (yet).