### PR TITLE
Safely log Shipwire requests and responses.

### DIFF
--- a/lib/active_fulfillment/services/shipwire.rb
+++ b/lib/active_fulfillment/services/shipwire.rb
@@ -171,7 +171,11 @@ module ActiveFulfillment
     end
 
     def commit(action, request)
+      log_query = request.dup
+      [@options[:password], affiliate_id].each { |key| log_query.gsub!(/#{key}/, '[filtered]') if key.present? }
+      logger.info "[#{self.class}][#{SERVICE_URLS[action]}][#{POST_VARS[action]}] query=#{log_query}"
       data = ssl_post(SERVICE_URLS[action], "#{POST_VARS[action]}=#{CGI.escape(request)}")
+      logger.info "[#{self.class}][result] #{data}"
 
       response = parse_response(action, data)
       Response.new(response[:success], response[:message], response, :test => test?)


### PR DESCRIPTION
Log the requests and responses from Shipwire, to help in debugging issues. Ensure we never log credentials.

We're seeing some new `exception_message="undefined method `child' for nil` errors when calling `fetch_stock_levels`, meaning we were always missing some tests here.

@kmcphillips @kevinhughes27 @ddrmanxbxfr