### PR TITLE
Remove REXML from Unit Tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,6 @@ require 'active_fulfillment'
 require 'minitest/autorun'
 require 'mocha/setup'
 require 'timecop'
-require 'rexml/document'
 
 require 'logger'
 ActiveFulfillment::Service.logger = Logger.new(nil)

--- a/test/unit/services/shipwire_test.rb
+++ b/test/unit/services/shipwire_test.rb
@@ -58,8 +58,8 @@ class ShipwireTest < Minitest::Test
   end
 
   def test_country_format
-    xml = REXML::Document.new(@shipwire.send(:build_fulfillment_request, '123456', @address, @line_items, @options))
-    country_node = REXML::XPath.first(xml, "//Country")
+    xml = Nokogiri::XML(@shipwire.send(:build_fulfillment_request, '123456', @address, @line_items, @options))
+    country_node = xml.at_xpath(xml, "//Country")
     assert_equal 'US', country_node.text
   end
 
@@ -106,8 +106,8 @@ class ShipwireTest < Minitest::Test
                   :password => 'test',
                   :include_empty_stock => true
                 )
-    xml = REXML::Document.new(@shipwire.send(:build_inventory_request, {}))
-    assert REXML::XPath.first(xml, '//IncludeEmpty')
+    xml = Nokogiri::XML(@shipwire.send(:build_inventory_request, {}))
+    assert xml.at_xpath(xml, '//IncludeEmpty')
   end
 
   def test_no_tracking_numbers_available
@@ -177,29 +177,30 @@ class ShipwireTest < Minitest::Test
 
   def test_affiliate_id
     ActiveFulfillment::ShipwireService.affiliate_id = 'affiliate_id'
-
-    xml = REXML::Document.new(@shipwire.send(:build_fulfillment_request, '123456', @address, @line_items, @options))
-    affiliate_id = REXML::XPath.first(xml, "//AffiliateId")
+    xml = Nokogiri::XML(@shipwire.send(:build_fulfillment_request, '123456', @address, @line_items, @options))
+    affiliate_id = xml.at_xpath(xml, "//AffiliateId")
     assert_equal 'affiliate_id', affiliate_id.text
   end
 
   def test_company_name_in_request
-    xml = REXML::Document.new(@shipwire.send(:build_fulfillment_request, '123456', @address, @line_items, @options))
-    company_node = REXML::XPath.first(xml, "//Company")
+    xml = Nokogiri::XML(@shipwire.send(:build_fulfillment_request, '123456', @address, @line_items, @options))
+    company_node = xml.at_xpath(xml, "//Company")
     assert_equal 'MyCorp', company_node.text
   end
 
   def test_order_excludes_note_by_default
-    xml = REXML::Document.new(@shipwire.send(:build_fulfillment_request, '123456', @address, @line_items, @options))
-    note_node = REXML::XPath.first(xml, "//Note").cdatas.first
-    assert_nil note_node
+    xml = Nokogiri::XML(@shipwire.send(:build_fulfillment_request, '123456', @address, @line_items, @options))
+    note_node = xml.at_xpath(xml, "//Note")
+    assert_equal 0, note_node.children.select { |child| child.cdata? }.size
+    assert_equal false, note_node.cdata?
   end
 
   def test_order_includes_note_when_present
     @options[:note] = "A test note"
-    xml = REXML::Document.new(@shipwire.send(:build_fulfillment_request, '123456', @address, @line_items, @options))
-    note_node = REXML::XPath.first(xml, "//Note").cdatas.first
-    assert_equal "A test note", note_node.to_s
+    xml = Nokogiri::XML(@shipwire.send(:build_fulfillment_request, '123456', @address, @line_items, @options))
+    note_node = xml.at_xpath(xml, "//Note")
+    assert_equal "A test note", note_node.text.strip
+    assert_equal note_node.children.select { |child| child.cdata? }.size, 1
   end
 
   def test_error_response_cdata_parsing


### PR DESCRIPTION
This PR converts the old tests that used REXML in favor of nokogiri.

Make sure to have a look at, test_order_includes_note_when_present. 

There is no method to fetch cdata directly in rexml. I converted it in favor of checking that cdata is present and compare the content itself.

@kevinhughes27 

Meta PR #68 