### PR TITLE
Ensure log filtering uses a string to replace.

### DIFF
--- a/lib/active_fulfillment/services/amazon_mws.rb
+++ b/lib/active_fulfillment/services/amazon_mws.rb
@@ -168,7 +168,7 @@ module ActiveFulfillment
       query = build_full_query(verb, uri, params)
       headers = build_headers(query)
       log_query = query.dup
-      [@options[:login], @options[:app_id], @mws_auth_token].each { |key| log_query.gsub!(key, '[filtered]') if key.present? }
+      [@options[:login], @options[:app_id], @mws_auth_token].each { |key| log_query.gsub!(key.to_s, '[filtered]') if key.present? }
 
       logger.info "[#{self.class}][#{action}] query=#{log_query}"
       data = ssl_post(uri.to_s, query, headers)

--- a/lib/active_fulfillment/services/shipwire.rb
+++ b/lib/active_fulfillment/services/shipwire.rb
@@ -172,7 +172,7 @@ module ActiveFulfillment
 
     def commit(action, request)
       log_query = request.dup
-      [@options[:password], affiliate_id].each { |key| log_query.gsub!(key, '[filtered]') if key.present? }
+      [@options[:password], affiliate_id].each { |key| log_query.gsub!(key.to_s, '[filtered]') if key.present? }
       logger.info "[#{self.class}][#{SERVICE_URLS[action]}][#{POST_VARS[action]}] query=#{log_query}"
       data = ssl_post(SERVICE_URLS[action], "#{POST_VARS[action]}=#{CGI.escape(request)}")
       logger.info "[#{self.class}][result] #{data}"

--- a/test/unit/services/shipwire_test.rb
+++ b/test/unit/services/shipwire_test.rb
@@ -84,6 +84,17 @@ class ShipwireTest < Minitest::Test
     response = @shipwire.fetch_stock_levels
   end
 
+  def test_logging_with_specific_passwords
+    @shipwire = ActiveFulfillment::ShipwireService.new(login: 'cody@example.com', password: 345)
+    @shipwire.class.logger.expects(:info).with do |message|
+      refute message.include?('345')
+      true
+    end.twice
+
+    @shipwire.stubs(:ssl_post).returns(xml_fixture('shipwire/inventory_get_response'))
+    response = @shipwire.fetch_stock_levels
+  end
+
   def test_stock_levels_include_pending_when_set
     @shipwire = ActiveFulfillment::ShipwireService.new(
                   :login => 'cody@example.com',


### PR DESCRIPTION
Ensure we are using `to_s` when doing log filtering.

@kmcphillips @kevinhughes27 