### PR TITLE
Check on success when parsing Shipwire response.

### DIFF
--- a/lib/active_fulfillment/services/shipwire.rb
+++ b/lib/active_fulfillment/services/shipwire.rb
@@ -224,8 +224,8 @@ module ActiveFulfillment
       response = { stock_levels: {} }
       Parsing.with_xml_document(xml, response) do |document|
         status = document.at_xpath('//Status'.freeze).child.content
-        total_products = document.at_xpath('//TotalProducts'.freeze).child.content
         success = test? ? status == 'Test'.freeze : status == '0'.freeze
+        total_products = success ? document.at_xpath('//TotalProducts'.freeze).child.content : 0
         message = success ? 'Successfully received the stock levels'.freeze : document.at_xpath('//ErrorMessage'.freeze).child.content
 
         {

--- a/test/fixtures/xml/shipwire/invalid_login_inventory_update_response.xml
+++ b/test/fixtures/xml/shipwire/invalid_login_inventory_update_response.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE InventoryUpdateResponse SYSTEM "http://www.shipwire.com/exec/download/InventoryUpdateResponse.dtd">
+<InventoryUpdateResponse>
+    <Status>Error</Status>
+    <ErrorMessage>Error with Valid Username/EmailAddress and Password Required. There is an error in XML document.</ErrorMessage>
+    <ProcessingTime units="ms" host="w2.lww.shipwire.com">63</ProcessingTime>
+</InventoryUpdateResponse>

--- a/test/unit/services/shipwire_test.rb
+++ b/test/unit/services/shipwire_test.rb
@@ -73,6 +73,14 @@ class ShipwireTest < Minitest::Test
     assert_equal 677, response.stock_levels['KingMonkey']
   end
 
+  def test_stock_levels_parses_invalid_credentials
+    @shipwire.expects(:ssl_post).returns(xml_fixture('shipwire/invalid_login_inventory_update_response'))
+
+    response = @shipwire.fetch_stock_levels
+    refute response.success?
+    assert_equal 'Error with Valid Username/EmailAddress and Password Required. There is an error in XML document.', response.message
+  end
+
   def test_stock_levels_logs_request_and_response
     @shipwire.class.logger.expects(:info).with do |message|
       assert_match /InventoryUpdate/, message unless message.include?('InventoryUpdateResponse')


### PR DESCRIPTION
Ensure we don't have a credential error when parsing our total products.

@kmcphillips @kevinhughes27 