### PR TITLE
Remove order_id params from Shopify API call.

### DIFF
--- a/lib/active_fulfillment/services/shopify_api.rb
+++ b/lib/active_fulfillment/services/shopify_api.rb
@@ -51,7 +51,7 @@ module ActiveFulfillment
     end
 
     def fetch_tracking_data(order_numbers, options = {})
-      options.merge!({:order_ids => order_numbers, :order_names => order_numbers})
+      options.merge!({:order_names => order_numbers})
       response = send_app_request('fetch_tracking_numbers'.freeze, options.delete(:headers), options)
       if response
         tracking_numbers = parse_response(response, 'TrackingNumbers'.freeze, 'Order'.freeze, 'ID'.freeze, 'Tracking'.freeze) { |o| o }


### PR DESCRIPTION
This was marked as deprecated a year ago, with a corresponding forum announcement: https://ecommerce.shopify.com/c/api-announcements/t/deprecation-notice-update-to-content-sent-to-tracking_numbers-endpoint-of-fulfillment-services-218632


