### PR TITLE
Test Rails 5, active_support and active_utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,11 @@ cache: bundler
 rvm:
 - 2.0
 - 2.1
-- 2.2
+- 2.2.2
 - 2.3.0
 
 gemfile:
+- Gemfile
 - Gemfile.activesupport32
 - Gemfile.activesupport40
 - Gemfile.activesupport41
@@ -18,6 +19,10 @@ gemfile:
 
 matrix:
   exclude:
+    - rvm: 2.0
+      gemfile: Gemfile
+    - rvm: 2.1
+      gemfile: Gemfile
     - rvm: 2.0
       gemfile: Gemfile.activesupport5
     - rvm: 2.1

--- a/Gemfile.activesupport5
+++ b/Gemfile.activesupport5
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 gemspec
 
-gem 'activesupport', github: 'rails/rails'
+gem 'activesupport', '~> 5.0.0'
+gem 'active_utils', '~> 3.2.2'

--- a/active_fulfillment.gemspec
+++ b/active_fulfillment.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.3.7}
   s.summary = %q{Framework and tools for dealing with shipping, tracking and order fulfillment services.}
 
-  s.add_dependency('activesupport', '>= 3.2.9')
+  s.add_dependency('activesupport', '>= 3.2.9', '< 5.1.0')
   s.add_dependency('builder', '>= 2.0.0')
   s.add_dependency('active_utils', '~> 3.0')
   s.add_dependency('nokogiri', '~> 1.6')


### PR DESCRIPTION
Adds testing for Rails 5 active_support/active_utils. Also adds upper version restriction on the ActiveSupport dependency.

@kmcphillips @jonathankwok @garethson 