### PR TITLE
TimeoutError is deprecated

### DIFF
--- a/lib/active_fulfillment/services/shopify_api.rb
+++ b/lib/active_fulfillment/services/shopify_api.rb
@@ -8,7 +8,6 @@ module ActiveFulfillment
     RESCUABLE_CONNECTION_ERRORS = [
       Net::ReadTimeout,
       Net::OpenTimeout,
-      TimeoutError,
       Errno::ETIMEDOUT,
       Timeout::Error,
       IOError,


### PR DESCRIPTION
TimeoutError is deprecated in favor of Timeout::Error. 

@kmcphillips @garethson 