### PR TITLE
Test against ruby 2.4 + Lock nokogiri dependency for ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
 - 2.1
 - 2.2.2
 - 2.3.1
+- 2.4.0
 
 gemfile:
 - Gemfile
@@ -27,3 +28,11 @@ matrix:
       gemfile: gemfiles/activesupport50.gemfile
     - rvm: 2.1
       gemfile: gemfiles/activesupport50.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/activesupport32.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/activesupport40.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/activesupport41.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/activesupport42.gemfile

--- a/active_fulfillment.gemspec
+++ b/active_fulfillment.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '>= 3.2.9', '< 5.1.0')
   s.add_dependency('builder', '>= 2.0.0')
   s.add_dependency('active_utils', '~> 3.0')
-  s.add_dependency('nokogiri', '~> 1.6')
+  s.add_dependency('nokogiri', '~> 1.6.8')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha', '~> 1.1')


### PR DESCRIPTION
Ruby 2.4 released for christmas.

We should probably test against it...

Do note that Ruby 2.4 is only supported from Rails 5 and higher !

I also had to lock the nokogiri version correctly if we still want to support ruby 2.0...