### PR TITLE
Use the TotalSupplyQuantity over the InSupplyStock quantity 

### DIFF
--- a/lib/active_fulfillment/services/amazon_mws.rb
+++ b/lib/active_fulfillment/services/amazon_mws.rb
@@ -237,7 +237,7 @@ module ActiveFulfillment
       document.css('InventorySupplyList > member'.freeze).each do |node|
         params = node.elements.to_a.each_with_object({}) { |elem, hash| hash[elem.name] = elem.text }
 
-        response[:stock_levels][params['SellerSKU']] = params['InStockSupplyQuantity'].to_i
+        response[:stock_levels][params['SellerSKU']] = params['TotalSupplyQuantity'].to_i
       end
 
       next_token = document.at_css('NextToken'.freeze)

--- a/test/unit/services/amazon_mws_test.rb
+++ b/test/unit/services/amazon_mws_test.rb
@@ -292,7 +292,7 @@ class AmazonMarketplaceWebServiceTest < Minitest::Test
     response = @service.fetch_stock_levels
     assert response.success?
     assert_equal 202, response.stock_levels['GN-00-01A']
-    assert_equal 199, response.stock_levels['GN-00-02A']
+    assert_equal 240, response.stock_levels['GN-00-02A']
   end
 
   def test_get_inventory_multipage
@@ -311,9 +311,9 @@ class AmazonMarketplaceWebServiceTest < Minitest::Test
     assert response.success?
 
     assert_equal 202, response.stock_levels['GN-00-01A']
-    assert_equal 199, response.stock_levels['GN-00-02A']
-    assert_equal 0, response.stock_levels['GN-01-01A']
-    assert_equal 5259, response.stock_levels['GN-01-02A']
+    assert_equal 240, response.stock_levels['GN-00-02A']
+    assert_equal 123, response.stock_levels['GN-01-01A']
+    assert_equal 321, response.stock_levels['GN-01-02A']
   end
 
   def test_get_inventory_multipage_missing_stock


### PR DESCRIPTION
## About
This PR changes the stock levels returned in the `#fetch_stock_levels` method to be the **Total** supply stock quantity, not the In Supply stock quantity.

## Reasoning
In-supply stock levels should be a concern of the API consumer, since they know best what is available on hand.

CC: @jbruton @garethson 
