### PR TITLE
Require resolv before trying to use

### DIFF
--- a/lib/active_fulfillment/services/shopify_api.rb
+++ b/lib/active_fulfillment/services/shopify_api.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/object/to_query'
+require 'resolv'
 
 module ActiveFulfillment
   class ShopifyAPIService < Service


### PR DESCRIPTION
It was working before because bundler did require `rubygems/spec_fetcher` and that file requires `resolv`. We should not rely on that since any time rubygems can change.

Related https://github.com/bundler/bundler/commit/984f64d8a5771b214136b1bc5ffdfa83d4503252
https://github.com/rubygems/rubygems/blob/master/lib/rubygems/spec_fetcher.rb#L2
https://github.com/rubygems/rubygems/blob/master/lib/rubygems/remote_fetcher.rb#L7