### PR TITLE
Release version 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ActiveFulfillment changelog
 
+### Version 3.1.0 (March 2017)
+- Update dependencies
+
 ### Version 3.0.1 (January 2015)
 
 - Use Nokogiri for all xml handling.

--- a/lib/active_fulfillment/version.rb
+++ b/lib/active_fulfillment/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module ActiveFulfillment
-  VERSION = "3.0.8"
+  VERSION = "3.1.0"
 end


### PR DESCRIPTION
Bumping active_utils dependency to `~> 3.3.0`, to support changes implemented on https://github.com/Shopify/active_utils/pull/78 and https://github.com/Shopify/active_utils/pull/79.

