### PR TITLE
Allow to customize a maximum log limit for API response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # ActiveFulfillment changelog
 
+### Version 3.2.1
+
+- Allow truncating the Amazon response log.
+
+### Version 3.2.0
+
+- Add support for ActiveSupport 5.1
+
 ### Version 3.1.1 (March 2017)
+
 - Bump Nokogiri dependency >= 1.6.8.
 
 ### Version 3.1.0 (March 2017)
+
 - Update dependencies
 
 ### Version 3.0.1 (January 2015)

--- a/lib/active_fulfillment/version.rb
+++ b/lib/active_fulfillment/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module ActiveFulfillment
-  VERSION = "3.2.0"
+  VERSION = "3.2.1"
 end


### PR DESCRIPTION
Logs end-up being truncated due to the size of some API responses.

How about we limit the log size here?