### PR TITLE
Enable error handling to retry a given amount of times

### DIFF
--- a/lib/active_fulfillment/services/amazon_mws.rb
+++ b/lib/active_fulfillment/services/amazon_mws.rb
@@ -117,7 +117,7 @@ module ActiveFulfillment
         parse_inventory_response(parse_document(data))
       end
       while token = response.params['next_token'] do
-        next_page = with_error_handling do
+        next_page = with_error_handling(max_retries) do
           data = commit :post, 'FulfillmentInventory', build_next_inventory_list_request(token)
           parse_inventory_response(parse_document(data))
         end
@@ -436,7 +436,7 @@ module ActiveFulfillment
       begin
         yield
       rescue ActiveUtils::ResponseError => e
-        if e.response == 503 && retries < max_retries
+        if e.response.code == 503 && retries < max_retries
           retries += 1
           retry
         else

--- a/test/unit/services/amazon_mws_test.rb
+++ b/test/unit/services/amazon_mws_test.rb
@@ -499,6 +499,15 @@ class AmazonMarketplaceWebServiceTest < Minitest::Test
     assert !constructed_address[nil]
   end
 
+  def test_retry_on_error
+    retries = 5
+    http_response = build_mock_response(response_from_503, "", 503)
+    @service.expects(:ssl_post).raises(ActiveUtils::ResponseError.new(http_response)).times(retries + 1)
+
+    response = @service.fetch_stock_levels(max_retries: retries)
+    assert !response.success?
+  end
+
   private
   def build_mock_response(response, message, code = "200")
     http_response = stub(:code => code, :message => message)

--- a/test/unit/services/amazon_mws_test.rb
+++ b/test/unit/services/amazon_mws_test.rb
@@ -505,7 +505,7 @@ class AmazonMarketplaceWebServiceTest < Minitest::Test
     @service.expects(:ssl_post).raises(ActiveUtils::ResponseError.new(http_response)).times(retries + 1)
 
     response = @service.fetch_stock_levels(max_retries: retries)
-    assert !response.success?
+    refute_predicate response, :success?
   end
 
   private


### PR DESCRIPTION
Expands the current error handling in `AmazonMarketplaceWebService` to allow for retries on 503s when fetching stock levels.  This change is backwards-compatible, used by passing `max_retries` to `fetch_stock_levels` as an additional option.  The value defaults to 0 to maintain current default behaviour.

@Shopify/inventory 