### PR TITLE
Truncate the response when logging it

### DIFF
--- a/lib/active_fulfillment.rb
+++ b/lib/active_fulfillment.rb
@@ -26,6 +26,7 @@ require 'active_support/core_ext/time/calculations'
 require 'active_support/core_ext/date/calculations'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/enumerable'
+require 'active_support/core_ext/string'
 begin
   require 'active_support/core_ext/time/acts_like'
 rescue LoadError

--- a/lib/active_fulfillment/services/shopify_api.rb
+++ b/lib/active_fulfillment/services/shopify_api.rb
@@ -6,6 +6,8 @@ module ActiveFulfillment
 
     OrderIdCutoffDate = Date.iso8601('2015-03-01').freeze
 
+    MAX_LOGGED_RESPONSE_LENGTH = 70
+
     RESCUABLE_CONNECTION_ERRORS = [
       Net::ReadTimeout,
       Net::OpenTimeout,
@@ -86,9 +88,18 @@ module ActiveFulfillment
         end
       end
 
-      log :info, "GET response action=#{action} in #{"%.4fs" % realtime} #{response}"
-
+      log_response(action, realtime, response)
       response
+    end
+
+    def log_response(action, realtime, response)
+      truncated = response.to_s.truncate(
+        MAX_LOGGED_RESPONSE_LENGTH,
+        omission: '[response truncated]'
+      )
+
+      log :info, "GET response action=#{action} in " \
+        "#{format('%.4fs', realtime)} #{truncated}"
     end
 
     def parse_json(json_data, root)


### PR DESCRIPTION
The response for `GET response action=fetch_stock` can be over 500k characters long. 
This is including more information than useful in logs and can cause other useful information to be dropped. 

`70` is arbitrary, how much data would be enough to be useful for this log? 
