### PR TITLE
Increase Amazon read timeout to 20s

### DIFF
--- a/lib/active_fulfillment/services/amazon_mws.rb
+++ b/lib/active_fulfillment/services/amazon_mws.rb
@@ -62,6 +62,8 @@ module ActiveFulfillment
       'Priority Shipping' => 'Priority'
     }.freeze
 
+    READ_TIMEOUT = 20
+
     # The first is the label, and the last is the code
     # Standard:  3-5 business days
     # Expedited: 2 business days
@@ -75,6 +77,7 @@ module ActiveFulfillment
       @seller_id = options[:seller_id]
       @mws_auth_token = options[:mws_auth_token]
       @maximum_response_log_size = options[:maximum_response_log_size] || 0
+      @read_timeout = READ_TIMEOUT
       super
     end
 

--- a/test/unit/services/amazon_mws_test.rb
+++ b/test/unit/services/amazon_mws_test.rb
@@ -508,6 +508,12 @@ class AmazonMarketplaceWebServiceTest < Minitest::Test
     refute_predicate response, :success?
   end
 
+  def test_read_timeout_longer_than_default
+    default_service = ActiveFulfillment::Service.new
+
+    assert_operator default_service.read_timeout, :<, @service.read_timeout
+  end
+
   private
   def build_mock_response(response, message, code = "200")
     http_response = stub(:code => code, :message => message)


### PR DESCRIPTION
**WHAT are you trying to accomplish with this PR?**

Relates https://github.com/Shopify/shopify/issues/157816

We've seen an increasing number of amazon fulfillment requests that timeout and fail but when that occurs it is possible that the amazon fulfillment has succeeded. This PR attempts to minimize the frequency of this happening by increasing the read timeout on amazon fulfillment requests.

**HOW is this accomplished?**

Note that the open timeout is not touched. Connection opening will timeout if the external service is unavailable or cannot be reached; when this occurs the fulfillment request is NOT issued and thus we correctly treat it as a failed attempt. This connection error is out of scope for this PR.

Analysis of fulfillment logs shows the vast majority of Amazon request response time within 2s but the frequency distribution tails off slowly with a handful above 8s. Since request read timeouts will cause the fulfillment to be marked failed but it is possible that Amazon actually successfully received and processed the request, we increase the read timeout from 10s to 20s as an easy way of decreasing the chance of this edge case from occurring.

Also to note, the requests to external services are done asynchronously so we can expect that increasing the timeout will increase the number of concurrent requests; however, this should be minimized since most requests are very fast.

This fix should be monitored over the next couple weeks to verify that the frequency of the timeouts is in fact decreasing to buy us some time to decide how best to fix the effects of the problem.

See the related bug for Splunk reports backing up these findings.

**WHY are you choosing this approach?**

Increasing the read timeout is relatively innocuous change to make with little negative effects. If the above analysis is correct this should greatly decrease the occurrences of such read timeouts and it's thus its effects. As well, we now know how to monitor for this error and we can directly see if this change is making a material difference.

CC @Shopify/fulfillment 