### PR TITLE
 Remove upperbound constraint on ActiveSupport:

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,7 @@ inherit_from:
 
 AllCops:
   TargetRubyVersion: 2.2
+
+Style/MethodCallWithArgsParentheses:
+  Exclude:
+    - 'gemfiles/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: bundler
 rvm:
 - 2.2.2
 - 2.3.1
-- 2.4.0
+- 2.4.4
 
 gemfile:
 - Gemfile
@@ -15,8 +15,13 @@ gemfile:
 - gemfiles/activesupport50.gemfile
 - gemfiles/activesupport51.gemfile
 - gemfiles/activesupport52.gemfile
+- gemfiles/activesupport_master.gemfile
 
 matrix:
   exclude:
-    - rvm: 2.4.0
+    - rvm: 2.4.4
       gemfile: gemfiles/activesupport42.gemfile
+    - rvm: 2.2.2
+      gemfile: gemfiles/activesupport_master.gemfile
+    - rvm: 2.3.1
+      gemfile: gemfiles/activesupport_master.gemfile

--- a/active_fulfillment.gemspec
+++ b/active_fulfillment.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.summary = %q{Framework and tools for dealing with shipping, tracking and order fulfillment services.}
 
   s.required_ruby_version = '~> 2.2'
-  s.add_dependency('activesupport', '>= 4.2.0', '< 6.0')
+  s.add_dependency('activesupport', '>= 4.2.0')
   s.add_dependency('builder', '>= 2.0.0')
   s.add_dependency('active_utils', '~> 3.3.1')
   s.add_dependency('nokogiri', '>= 1.6.8')

--- a/gemfiles/activesupport32.gemfile
+++ b/gemfiles/activesupport32.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gemspec path: '..'
-
-gem 'activesupport', '~> 3.2.0'
-gem 'nokogiri', '= 1.6.8'

--- a/gemfiles/activesupport32_nokogiri_17.gemfile
+++ b/gemfiles/activesupport32_nokogiri_17.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gemspec path: '..'
-
-gem 'activesupport', '~> 3.2.0'
-gem 'nokogiri', '>= 1.7'

--- a/gemfiles/activesupport40.gemfile
+++ b/gemfiles/activesupport40.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gemspec path: '..'
-
-gem 'activesupport', '~> 4.0.0'
-gem 'nokogiri', '= 1.6.8'

--- a/gemfiles/activesupport40_nokogiri_17.gemfile
+++ b/gemfiles/activesupport40_nokogiri_17.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gemspec path: '..'
-
-gem 'activesupport', '~> 4.0.0'
-gem 'nokogiri', '>= 1.7'

--- a/gemfiles/activesupport41.gemfile
+++ b/gemfiles/activesupport41.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gemspec path: '..'
-
-gem 'activesupport', '~> 4.1.0'
-gem 'nokogiri', '= 1.6.8'

--- a/gemfiles/activesupport41_nokogiri_17.gemfile
+++ b/gemfiles/activesupport41_nokogiri_17.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gemspec path: '..'
-
-gem 'activesupport', '~> 4.1.0'
-gem 'nokogiri', '>= 1.7'

--- a/gemfiles/activesupport51.gemfile
+++ b/gemfiles/activesupport51.gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec path: '..'
 
-gem 'activesupport', '~> 5.1'
+gem 'activesupport', '~> 5.1.0'

--- a/gemfiles/activesupport_master.gemfile
+++ b/gemfiles/activesupport_master.gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec path: '..'
 
-gem 'activesupport', '~> 5.2.0'
+gem 'activesupport', github: 'rails/rails'


### PR DESCRIPTION
Remove upperbound constraint on ActiveSupport:

- Looking at this gem, there is no reason to have a upperbound
  constraint on ActiveSupport.
  It just blocks us whenever there is a new Rails upgrade.

  This commit removes the upperbound constraint and test this gem on
  the latest commig of ActiveSupport.

  Also fixing previous gemfiles (5.2.0 is released), and 5.1 wasn't
  testing 5.1 but 5.2 because of the wrong pessismistic constraint.


------------ 



Remove unused gemfiles, we dropped support for then in 1481abd