### PR TITLE
Sending MarketplaceId to all FBA requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ActiveFulfillment changelog
 
+### Version 3.2.8 (December 20, 2019)
+- Sending MarketplaceId for all Amazon requests
+
 ### Version 3.2.7 (November 30, 2018)
 - Fixing Amazon endpoint used for the CA and MX marketplaces
 

--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,7 @@
 name: active-fulfillment
 
 up:
-  - ruby: 2.3.1
+  - ruby: 2.6.5
   - bundler
 
 commands:

--- a/lib/active_fulfillment/services/amazon_mws.rb
+++ b/lib/active_fulfillment/services/amazon_mws.rb
@@ -356,6 +356,7 @@ module ActiveFulfillment
       opts["SignatureVersion"] = SIGNATURE_VERSION unless opts["SignatureVersion"]
       opts["SellerId"] = @seller_id unless opts["SellerId"] || !@seller_id
       opts["MWSAuthToken"] = @mws_auth_token unless opts["MWSAuthToken"] || !@mws_auth_token
+      opts["MarketplaceId"] = marketplace_id
       opts
     end
 
@@ -366,7 +367,6 @@ module ActiveFulfillment
         :DisplayableOrderId => order_id.to_s,
         :DisplayableOrderDateTime => options[:order_date].utc.iso8601,
         :ShippingSpeedCategory => options[:shipping_method],
-        :MarketplaceId => marketplace_id,
       }
       params[:DisplayableOrderComment] = options[:comment] if options[:comment]
 

--- a/lib/active_fulfillment/version.rb
+++ b/lib/active_fulfillment/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module ActiveFulfillment
-  VERSION = "3.2.7"
+  VERSION = "3.2.8"
 end

--- a/test/unit/services/amazon_mws_test.rb
+++ b/test/unit/services/amazon_mws_test.rb
@@ -89,13 +89,14 @@ class AmazonMarketplaceWebServiceTest < Minitest::Test
       "FeedType" => "_POST_INVENTORY_AVAILABILITY_DATA_",
       "Merchant" => "SuperMerchant123"
     }
-    expected_keys = ["AWSAccessKeyId", "Action", "FeedType", "Merchant", "SignatureMethod", "SignatureVersion", "Timestamp", "Version"]
+    expected_keys = ["AWSAccessKeyId", "Action", "FeedType", "Merchant", "SignatureMethod", "SignatureVersion", "Timestamp", "Version", "MarketplaceId"]
     opts = @service.build_basic_api_query(options)
     assert_equal expected_keys.sort, opts.keys.map(&:to_s).sort
     assert_equal "login", opts["AWSAccessKeyId"]
     assert_equal ActiveFulfillment::AmazonMarketplaceWebService::SIGNATURE_VERSION, opts["SignatureVersion"]
     assert_equal "Hmac#{ActiveFulfillment::AmazonMarketplaceWebService::SIGNATURE_METHOD}", opts["SignatureMethod"]
     assert_equal ActiveFulfillment::AmazonMarketplaceWebService::VERSION, opts["Version"]
+    assert_equal "ATVPDKIKX0DER", opts["MarketplaceId"]
   end
 
   def test_build_inventory_list_request
@@ -113,7 +114,7 @@ class AmazonMarketplaceWebServiceTest < Minitest::Test
 
   def test_create_signature
     service = ActiveFulfillment::AmazonMarketplaceWebService.new(:login => "0PExampleR2", :password => "sekrets")
-    expected_signature = "39XxH6iKLysjjDmWZSkyr2z8iSxfECHBYE1Pd0Qqpwo%3D"
+    expected_signature = "Zde8skcLEYlpbj27jSdTVGZ%2FWNcs4gDLXMdcQ8cvOrY%3D"
     options = {
       "AWSAccessKeyId" => "0PExampleR2",
       "Action" => "SubmitFeed",
@@ -123,7 +124,8 @@ class AmazonMarketplaceWebServiceTest < Minitest::Test
       "SignatureMethod" => "HmacSHA256",
       "SignatureVersion" => "2",
       "Timestamp" => "2009-08-20T01:10:27.607Z",
-      "Version" => "2009-01-01"
+      "Version" => "2009-01-01",
+      "MarketplaceId" => "ATVPDKIKX0DER"
     }
 
     uri = URI.parse("https://#{ActiveFulfillment::AmazonMarketplaceWebService::ENDPOINTS[:us]}")


### PR DESCRIPTION
I identified that `MarketplaceId` was only being sent on the `fulfill` requests, but not on the other ones (including `fetch_stock`).

This PR makes `MarketplaceId` part of all requests going to Amazon, making sure the correct marketplace is hit