### PR TITLE
Fix issue with trailing slash on callback url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ActiveFulfillment changelog
 
+### Version 3.2.9 (January 30, 2020)
+- Fix an issue with trailing slash on callback urls
+
 ### Version 3.2.8 (December 20, 2019)
 - Sending MarketplaceId for all Amazon requests
 

--- a/lib/active_fulfillment/services/shopify_api.rb
+++ b/lib/active_fulfillment/services/shopify_api.rb
@@ -68,7 +68,7 @@ module ActiveFulfillment
     private
 
     def request_uri(action, data)
-      URI.parse "#{@callback_url}/#{action}.#{@format}?#{data.to_query}"
+      url = URI.join(@callback_url, "#{action}.#{@format}?#{data.to_query}")
     end
 
     def send_app_request(action, headers, data)

--- a/lib/active_fulfillment/version.rb
+++ b/lib/active_fulfillment/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module ActiveFulfillment
-  VERSION = "3.2.8"
+  VERSION = "3.2.9"
 end

--- a/test/unit/services/shopify_api_test.rb
+++ b/test/unit/services/shopify_api_test.rb
@@ -22,6 +22,19 @@ class ShopifyAPITest < Minitest::Test
     end
   end
 
+  def test_request_uri_is_correct_when_callback_url_has_trailing_slash
+    Timecop.freeze do
+      service = build_service(callback_url: 'http://supershopifyapptwin.com/')
+      timestamp = Time.now.utc.to_i
+      uri = service.send(:request_uri, 'fetch_stock', {sku: '123', timestamp: timestamp, shop: 'www.snowwowdevil.ca'})
+      assert_equal "http://supershopifyapptwin.com/fetch_stock.json?shop=www.snowwowdevil.ca&sku=123&timestamp=#{timestamp}", uri.to_s
+
+      service = build_service(callback_url: 'http://supershopifyapptwin.com')
+      uri = service.send(:request_uri, 'fetch_stock', {sku: '123', timestamp: timestamp, shop: 'www.snowwowdevil.ca'})
+      assert_equal "http://supershopifyapptwin.com/fetch_stock.json?shop=www.snowwowdevil.ca&sku=123&timestamp=#{timestamp}", uri.to_s
+    end
+  end
+
   def test_response_from_failed_stock_request
     mock_app_request('fetch_stock', anything, nil)
     response = @service.fetch_stock_levels()


### PR DESCRIPTION
Fixes https://github.com/Shopify/active_fulfillment/issues/112

When a fulfillment service is created through Admin API, the callback url can have a trailing slash added. This causes an issue when the request URI is built and could contain two slashes in the URI. E.g. `http://myapp.com//fetch_stock.json?max_retries=3&shop=shop.myshopify.com&timestamp=1580412307`

This PR fixes the issue by removing extraneous `/` from the request URI.
