### PR TITLE
Handle callback_url with extra element with no trailing slash

### DIFF
--- a/lib/active_fulfillment/services/shopify_api.rb
+++ b/lib/active_fulfillment/services/shopify_api.rb
@@ -68,7 +68,7 @@ module ActiveFulfillment
     private
 
     def request_uri(action, data)
-      url = URI.join(@callback_url, "#{action}.#{@format}?#{data.to_query}")
+      url = File.join(@callback_url, "#{action}.#{@format}?#{data.to_query}")
     end
 
     def send_app_request(action, headers, data)

--- a/test/unit/services/shopify_api_test.rb
+++ b/test/unit/services/shopify_api_test.rb
@@ -35,6 +35,19 @@ class ShopifyAPITest < Minitest::Test
     end
   end
 
+  def test_request_uri_is_correct_when_callback_url_has_additional_element
+    Timecop.freeze do
+      service = build_service(callback_url: 'https://dotcom-prod.bluemercuryio.com/v1/dotcom')
+      timestamp = Time.now.utc.to_i
+      uri = service.send(:request_uri, 'fetch_stock', {sku: '123', timestamp: timestamp, shop: 'www.snowwowdevil.ca'})
+      assert_equal "https://dotcom-prod.bluemercuryio.com/v1/dotcom/fetch_stock.json?shop=www.snowwowdevil.ca&sku=123&timestamp=#{timestamp}", uri.to_s
+
+      service = build_service(callback_url: 'http://supershopifyapptwin.com/shopify')
+      uri = service.send(:request_uri, 'fetch_stock', {sku: '123', timestamp: timestamp, shop: 'www.snowwowdevil.ca'})
+      assert_equal "http://supershopifyapptwin.com/shopify/fetch_stock.json?shop=www.snowwowdevil.ca&sku=123&timestamp=#{timestamp}", uri.to_s
+    end
+  end
+
   def test_response_from_failed_stock_request
     mock_app_request('fetch_stock', anything, nil)
     response = @service.fetch_stock_levels()

--- a/test/unit/services/shopify_api_test.rb
+++ b/test/unit/services/shopify_api_test.rb
@@ -42,7 +42,7 @@ class ShopifyAPITest < Minitest::Test
       uri = service.send(:request_uri, 'fetch_stock', {sku: '123', timestamp: timestamp, shop: 'www.snowwowdevil.ca'})
       assert_equal "https://dotcom-prod.bluemercuryio.com/v1/dotcom/fetch_stock.json?shop=www.snowwowdevil.ca&sku=123&timestamp=#{timestamp}", uri.to_s
 
-      service = build_service(callback_url: 'http://supershopifyapptwin.com/shopify')
+      service = build_service(callback_url: 'http://supershopifyapptwin.com/shopify/')
       uri = service.send(:request_uri, 'fetch_stock', {sku: '123', timestamp: timestamp, shop: 'www.snowwowdevil.ca'})
       assert_equal "http://supershopifyapptwin.com/shopify/fetch_stock.json?shop=www.snowwowdevil.ca&sku=123&timestamp=#{timestamp}", uri.to_s
     end


### PR DESCRIPTION
**Why?**
`fetch_stock` and other calls dependent on callback_url are failing for a lot of merchants that have an additional element in the callback url, we got multiple requests from TMS in #store-logistics-runteam. Issue: https://github.com/Shopify/shopify/issues/259727

It seems to work for most callback_url (like `http://supershopifyapptwin.com/` used in the existing test), however it breaks when the callback url is a trailing segment without a / , which the merchants seems to be using (like https://api.landmarkglobal.com/shopify or https://dotcom-prod.bluemercuryio.com/v1/dotcom ) 

**What?**
Seems like this PR: https://github.com/Shopify/active_fulfillment/pull/113 fixed the issue related to trailing `/` if present in the URL, but introduced a new problem that removes end segment of the URL if it doesn't end with `/`. A [known problem](https://apidock.com/ruby/v2_5_5/URI/join/class) with `URI.join`. The only way this would work is if we update all our helpdocs to include a trailing `/` for the callback_urls or explicitly add it if it's not present.

**How?**
- Using `File.join` instead of `URI.join`.
- Seems like `File.join` solves the previous issue of trailing `/` in URL as well as if there is no trailing `/` and additional segment is present.
- Researched a bit online for best way to join paths in Ruby, so far all resources point to using `File.join`:
https://stackoverflow.com/questions/597488/how-to-do-a-safe-join-pathname-in-ruby
https://berk.es/2013/03/21/please-ruby-devs-join-your-paths/
https://stackoverflow.com/questions/3582732/why-should-i-use-file-join

**Risks**
- Could there be cases where `File.join` does not work? Is it OS dependent (does not seem so, but if someone has a different experience. Maybe on Windows?)
- Any more test cases I should add?
- Although current approach is cleaner, should I use an if else block to check for trailing `/` and handle it accordingly instead?