### PR TITLE
Update version 3.2.11 following the fix to callback url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ActiveFulfillment changelog
 
+### Version 3.2.11 (September 11, 2020)
+- Fix callback url to handle trailing segment and trailing slash
+
 ### Version 3.2.10 (September 1, 2020)
 - Relax ruby version requirement to allow installation on Ruby 3.0
 

--- a/lib/active_fulfillment/version.rb
+++ b/lib/active_fulfillment/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module ActiveFulfillment
-  VERSION = "3.2.10"
+  VERSION = "3.2.11"
 end


### PR DESCRIPTION
Updating the version to `3.2.11` following the fix to callback urls : https://github.com/Shopify/active_fulfillment/pull/114