### PR TITLE
Prepare bump version to 3.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ActiveFulfillment changelog
 
+### Version 3.2.12 (April 1, 2024)
+- Change active_utils from pecimistic to optimistic version constraint
+- Remove CLA from probot and use new GitHub action
+- Clean up service.yml manifest
+
 ### Version 3.2.11 (September 11, 2020)
 - Fix callback url to handle trailing segment and trailing slash
 

--- a/lib/active_fulfillment/version.rb
+++ b/lib/active_fulfillment/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module ActiveFulfillment
-  VERSION = "3.2.11"
+  VERSION = "3.2.12"
 end


### PR DESCRIPTION
Difference between 3.2.11 and main https://github.com/Shopify/active_fulfillment/compare/v3.2.11...main